### PR TITLE
Removing the apis AT.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,7 +15,6 @@ jar {
         attributes([
             'Maven-Artifact': "${project.group}:${project.archivesBaseName}:${project.version}:api",
             'Timestamp': System.currentTimeMillis(),
-            'FMLAT': "jvoxelizer_at.cfg"
         ])
     }
 }


### PR DESCRIPTION
This fixes an error where mods that depend on JVox try to compile with useDepAt=true.